### PR TITLE
Merge downstream features from @rkraneis @sveldhuisen, with modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,14 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+nbproject
+nb-configuration.xml
+nbactions.xml
+.idea
+*.iml
+target
+build
+*~
+#*
+*#*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ Command line interface to Apache Velocity.
 ## Usage
 
 ```bash
-$ velocity -h
+$ velocity --help
 usage:
-velocity -c foo=bar -t template.wm [-o output.txt]
+velocity -c foo=bar,baz=qux -r /resource/path -t template.wm [-o output.txt] [-e euc-jp] [--verbose]
 
 arguments:
    -a, --about  display about message [optional]
    -h, --help  display help message [optional]
    -c, --context [class java.lang.String]  context as comma-separated key value pairs [required]
+   -r, --resource [class java.io.File]  resource path [optional]
    -t, --template [class java.io.File]  template file [required]
    -o, --output [class java.io.File]  output file, default stdout [optional]
+   -e, --encoding [class java.nio.charset.Charset]  encoding, default UTF-8 [optional]
+   -v, --verbose  display verbose log messages [optional]
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <scope>runtime</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,4 @@
+org.slf4j.simpleLogger.defaultLogLevel=warn
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.showShortLogName=true
+org.slf4j.simpleLogger.levelInBrackets=true


### PR DESCRIPTION
This pull request merges some of the downstream features in #4, specifically adding `--resource` for resource path and `--encoding` for specifying the charset.

EscapeTool seems to have gone missing in Velocity version 2.0, so I've left that out.

Logging also changed between Velocity 1.x and 2.0, so here I've added logging statements similar to that in #4, and a `--verbose` switch that uses trace level debugging instead of warn level.

I'm still not sure all of what is going on with the context handing in #4, I'll review that further and add it in a separate new pull request.